### PR TITLE
Further speedups by using array buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,19 @@ wasm-bindgen = "0.2.45"
 
 [dependencies.web-sys]
 version = "0.3.22"
-features = ["console",  'CanvasRenderingContext2d',
+features = [
+  'CanvasRenderingContext2d',
+  'console',
   'Document',
   'Element',
   'HtmlCanvasElement',
-  'Window']
+  'ImageData',
+  'Window'
+  ]
 
 
 [dependencies.embedded-graphics]
 version = "0.7.0"
+
+[dependencies.js-sys]
+version = "0.3"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ pub fn main_js() -> Result<(), JsValue> {
     {
         console::log_1(&"Couldn't draw circle".into());
     }
+
+    img_display.flush().expect("Couldn't update");
     Ok(())
 }
 
@@ -90,6 +92,8 @@ pub fn main_js() -> Result<(), JsValue> {
 ### How it works
 
 Embedded Graphics Web Simulator implements [`DrawTarget`](https://docs.rs/embedded-graphics/0.6.0/embedded_graphics/prelude/trait.DrawTarget.html) for the HTML `<canvas>` element.
+It will attach a `<canvas>` either to the document body, or to a user-supplied parent element.
+To minimize overhead, draw operations need to be explicitly `flush()`ed whenver you want to see an actual update.
 
 ## Credits
 

--- a/examples/animated/index.html
+++ b/examples/animated/index.html
@@ -4,9 +4,12 @@
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
 </head>
 
-<body>
-  <p id="text">A greeting from rust looks like...</div>
-  <div id="graphics"></div>
+<body
+  style="margin:0; padding:0; font-family: Arial, Helvetica, sans-serif; width: 100%; text-align: center; background-color: indigo; color:magenta">
+  <p id="text" style="background-color: black; padding: 0.5rem; border-bottom: 1px solid blueviolet">A greeting from
+    rust looks
+    like...
+  <div id="graphics" style="margin-top: 4rem; filter: drop-shadow(0 0 0.75rem black);"></div>
 </body>
 
 </html>

--- a/examples/animated/src/lib.rs
+++ b/examples/animated/src/lib.rs
@@ -37,7 +37,7 @@ fn text_container() -> web_sys::Element {
         .expect("document should have our text container")
 }
 
-const MARX: i32 = 70;
+const NUM_ITER: i32 = 60;
 
 // This function is automatically invoked after the wasm module is instantiated.
 #[wasm_bindgen(start)]
@@ -53,9 +53,9 @@ pub fn run() -> Result<(), JsValue> {
         .pixel_spacing(2)
         .build();
     let mut img_display = WebSimulatorDisplay::new(
-        (MARX as u32, MARX as u32),
+        (2 * NUM_ITER as u32, 2 * NUM_ITER as u32),
         &output_settings,
-        document.get_element_by_id("graphics"),
+        document.get_element_by_id("graphics").as_ref(),
     );
 
     // Here we want to call `requestAnimationFrame` in a loop, but only a fixed
@@ -77,7 +77,7 @@ pub fn run() -> Result<(), JsValue> {
     let mut i = 0;
 
     *g.borrow_mut() = Some(Closure::wrap(Box::new(move || {
-        if i > MARX - 4 {
+        if i > NUM_ITER - 4 {
             text_container().set_text_content(Some("All done!"));
 
             // Drop our handle to this closure so that it will get cleaned
@@ -94,14 +94,14 @@ pub fn run() -> Result<(), JsValue> {
 
         img_display
             .clear(Rgb565::CSS_LAVENDER)
-            .expect("clear should work man");
-        Circle::new(Point::new(MARX - i, MARX - i), i as u32 * 2)
+            .expect("could not clear()");
+        Circle::new(Point::new(NUM_ITER - i, NUM_ITER - i), i as u32 * 2)
             .into_styled(PrimitiveStyle::with_stroke(Rgb565::CSS_PINK, 1))
             .draw(&mut img_display)
-            .expect("draw should work man");
-
+            .expect("could not draw Circle");
         // Schedule ourself for another requestAnimationFrame callback.
         request_animation_frame(f.borrow().as_ref().unwrap());
+        i += 1;
     }) as Box<dyn FnMut()>));
 
     request_animation_frame(g.borrow().as_ref().unwrap());

--- a/examples/animated/src/lib.rs
+++ b/examples/animated/src/lib.rs
@@ -1,4 +1,4 @@
-use embedded_graphics::draw_target::DrawTarget;
+use embedded_graphics::{draw_target::DrawTarget, prelude::RgbColor};
 use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
@@ -92,9 +92,7 @@ pub fn run() -> Result<(), JsValue> {
         let text = format!("requestAnimationFrame has been called {} times.", i);
         text_container().set_text_content(Some(&text));
 
-        img_display
-            .clear(Rgb565::CSS_LAVENDER)
-            .expect("could not clear()");
+        img_display.clear(Rgb565::BLACK).expect("could not clear()");
         Circle::new(Point::new(NUM_ITER - i, NUM_ITER - i), i as u32 * 2)
             .into_styled(PrimitiveStyle::with_stroke(Rgb565::CSS_PINK, 1))
             .draw(&mut img_display)

--- a/examples/animated/src/lib.rs
+++ b/examples/animated/src/lib.rs
@@ -50,10 +50,11 @@ pub fn run() -> Result<(), JsValue> {
     let document = document();
     let output_settings = OutputSettingsBuilder::new()
         .scale(3)
-        .pixel_spacing(2)
+        .pixel_spacing(1)
         .build();
+    let size = (2 * NUM_ITER) as u32;
     let mut img_display = WebSimulatorDisplay::new(
-        (2 * NUM_ITER as u32, 2 * NUM_ITER as u32),
+        (size, size),
         &output_settings,
         document.get_element_by_id("graphics").as_ref(),
     );
@@ -77,7 +78,7 @@ pub fn run() -> Result<(), JsValue> {
     let mut i = 0;
 
     *g.borrow_mut() = Some(Closure::wrap(Box::new(move || {
-        if i > NUM_ITER - 4 {
+        if i > NUM_ITER {
             text_container().set_text_content(Some("All done!"));
 
             // Drop our handle to this closure so that it will get cleaned
@@ -93,10 +94,17 @@ pub fn run() -> Result<(), JsValue> {
         text_container().set_text_content(Some(&text));
 
         img_display.clear(Rgb565::BLACK).expect("could not clear()");
-        Circle::new(Point::new(NUM_ITER - i, NUM_ITER - i), i as u32 * 2)
+
+        for j in 0..5 {
+            Circle::new(
+                Point::new(NUM_ITER - i - 2 * j, NUM_ITER - i - 2 * j),
+                (2 * i + 4 * j) as u32,
+            )
             .into_styled(PrimitiveStyle::with_stroke(Rgb565::CSS_PINK, 1))
             .draw(&mut img_display)
             .expect("could not draw Circle");
+        }
+        img_display.flush().expect("could not flush buffer");
 
         // Schedule ourself for another requestAnimationFrame callback.
         request_animation_frame(f.borrow().as_ref().unwrap());

--- a/examples/animated/src/lib.rs
+++ b/examples/animated/src/lib.rs
@@ -1,4 +1,4 @@
-use embedded_graphics::{draw_target::DrawTarget, prelude::RgbColor};
+use embedded_graphics::{draw_target::DrawTarget, prelude::*, primitives::Rectangle};
 use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
@@ -49,7 +49,7 @@ pub fn run() -> Result<(), JsValue> {
 
     let document = document();
     let output_settings = OutputSettingsBuilder::new()
-        .scale(2)
+        .scale(3)
         .pixel_spacing(2)
         .build();
     let mut img_display = WebSimulatorDisplay::new(
@@ -97,6 +97,7 @@ pub fn run() -> Result<(), JsValue> {
             .into_styled(PrimitiveStyle::with_stroke(Rgb565::CSS_PINK, 1))
             .draw(&mut img_display)
             .expect("could not draw Circle");
+
         // Schedule ourself for another requestAnimationFrame callback.
         request_animation_frame(f.borrow().as_ref().unwrap());
         i += 1;

--- a/examples/basic/src/lib.rs
+++ b/examples/basic/src/lib.rs
@@ -68,5 +68,8 @@ pub fn main_js() -> Result<(), JsValue> {
     {
         console::log_1(&"Couldn't draw circle".into());
     }
+
+    img_display.flush().expect("could not flush buffer");
+
     Ok(())
 }

--- a/examples/basic/src/lib.rs
+++ b/examples/basic/src/lib.rs
@@ -42,7 +42,7 @@ pub fn main_js() -> Result<(), JsValue> {
     let mut img_display = WebSimulatorDisplay::new(
         (128, 128),
         &output_settings,
-        document.get_element_by_id("custom-container"),
+        document.get_element_by_id("custom-container").as_ref(),
     );
 
     let style = MonoTextStyle::new(&FONT_6X9, Rgb565::CSS_WHITE);
@@ -53,6 +53,7 @@ pub fn main_js() -> Result<(), JsValue> {
     {
         console::log_1(&"Couldn't draw text".into());
     }
+    text_display.flush().expect("could not flush buffer");
 
     // Load the BMP image
     let bmp = Bmp::from_slice(include_bytes!("./assets/rust-pride.bmp")).unwrap();

--- a/src/display.rs
+++ b/src/display.rs
@@ -6,8 +6,8 @@ use embedded_graphics::{
     prelude::*,
     primitives::Rectangle,
 };
-use std::{convert::TryInto, error::Error};
-use wasm_bindgen::{Clamped, JsCast};
+use std::error::Error;
+use wasm_bindgen::{Clamped, JsCast, JsValue};
 use web_sys::{CanvasRenderingContext2d, Element, HtmlCanvasElement, ImageData};
 
 /// WebSimulator display.
@@ -79,6 +79,15 @@ where
             _color_type: PhantomData,
         }
     }
+
+    pub fn flush(&mut self) -> Result<(), JsValue> {
+        let backing = self.backing.as_mut_slice();
+        let image_data =
+            ImageData::new_with_u8_clamped_array(Clamped(backing), self.canvas_size.width)
+                .expect("could not create ImageData");
+        self.context.put_image_data(&image_data, 0., 0.)?;
+        Ok(())
+    }
 }
 impl<C> OriginDimensions for WebSimulatorDisplay<C>
 where
@@ -127,15 +136,6 @@ where
                 }
             }
         }
-
-        let image_data = ImageData::new_with_u8_clamped_array(
-            Clamped(backing),
-            self.canvas_size.width.try_into().unwrap(),
-        )
-        .expect("could not create ImageData");
-        self.context
-            .put_image_data(&image_data, 0., 0.)
-            .expect("could not put ImageData");
 
         Ok(())
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -4,17 +4,20 @@ use embedded_graphics::{
     geometry::Size,
     pixelcolor::{PixelColor, Rgb888},
     prelude::*,
-    primitives::{self, Rectangle},
+    primitives::{self},
 };
 use std::{convert::TryInto, error::Error};
-use wasm_bindgen::{JsCast, JsValue};
-use web_sys::{Element, HtmlCanvasElement};
+use wasm_bindgen::{Clamped, JsCast};
+use web_sys::{CanvasRenderingContext2d, Element, HtmlCanvasElement, ImageData};
 
 /// WebSimulator display.
 pub struct WebSimulatorDisplay<C> {
     size: Size,
+    canvas_size: Size,
     canvas: HtmlCanvasElement,
     output_settings: OutputSettings,
+    backing: Vec<u8>,
+    context: CanvasRenderingContext2d,
     _color_type: PhantomData<C>,
 }
 
@@ -32,26 +35,20 @@ where
         parent: Option<&Element>,
     ) -> Self {
         // source: https://github.com/embedded-graphics/simulator/blob/master/src/output_settings.rs
-        let width = size.0 * output_settings.scale + (size.0 - 1) * output_settings.pixel_spacing;
+        let canvas_width =
+            size.0 * output_settings.scale + (size.0 - 1) * output_settings.pixel_spacing;
         // source: https://github.com/embedded-graphics/simulator/blob/master/src/output_settings.rs
-        let height = size.1 * output_settings.scale + (size.1 - 1) * output_settings.pixel_spacing;
+        let canvas_height =
+            size.1 * output_settings.scale + (size.1 - 1) * output_settings.pixel_spacing;
+
         let document = web_sys::window().unwrap().document().unwrap();
         let canvas = document.create_element("canvas").unwrap();
         let canvas: web_sys::HtmlCanvasElement = canvas
             .dyn_into::<web_sys::HtmlCanvasElement>()
             .map_err(|_| ())
             .unwrap();
-        canvas.set_width(width);
-        canvas.set_height(height);
-        let context = canvas
-            .get_context("2d")
-            .unwrap()
-            .unwrap()
-            .dyn_into::<web_sys::CanvasRenderingContext2d>()
-            .unwrap();
-
-        context.set_fill_style(&JsValue::from_str("black"));
-        context.fill_rect(0.0, 0.0, width as f64, height as f64);
+        canvas.set_width(canvas_width);
+        canvas.set_height(canvas_height);
         parent
             .unwrap_or(
                 &document
@@ -63,75 +60,26 @@ where
             )
             .append_child(&canvas)
             .expect("couldn't append canvas to parent");
-
-        WebSimulatorDisplay {
-            size: Size::new(width, height),
-            canvas,
-            output_settings: output_settings.clone(),
-            _color_type: PhantomData,
-        }
-    }
-
-    fn fill_rect(
-        canvas: &HtmlCanvasElement,
-        color: C,
-        area: &Rectangle,
-        scale: u32,
-        pitch: u32,
-    ) -> Result<(), Box<dyn Error>> {
         let context = canvas
             .get_context("2d")
             .unwrap()
             .unwrap()
             .dyn_into::<web_sys::CanvasRenderingContext2d>()
             .unwrap();
-        let color_rgb888 = color.into();
-
-        let css_color = format!(
-            "rgb({},{},{})",
-            color_rgb888.r(),
-            color_rgb888.g(),
-            color_rgb888.b()
-        );
-        context.set_fill_style(&JsValue::from_str(&css_color));
-
-        let width = area.size.width * scale;
-        let height = area.size.height * scale;
-
-        let scale: i32 = scale.try_into()?;
-        let pitch: i32 = pitch.try_into()?;
-
-        let origin = area.top_left;
-
-        context.fill_rect(
-            (origin.x * scale * pitch).try_into()?,
-            (origin.y * scale * pitch).try_into()?,
-            width.try_into()?,
-            height.try_into()?,
-        );
-        Ok(())
-    }
-
-    fn draw_pixel(&mut self, pixel: Pixel<C>) -> Result<(), core::convert::Infallible> {
-        let Pixel(coord, color) = pixel;
-        let scale = self.output_settings.scale;
 
         // source: https://github.com/embedded-graphics/simulator/blob/master/src/output_settings.rs#L39
-        let pitch = scale + self.output_settings.pixel_spacing;
 
-        Self::fill_rect(
-            &self.canvas,
-            color,
-            &Rectangle::new(coord, Size::new(scale, scale)),
-            scale,
-            pitch,
-        )
-        .expect("numeric conversion failed");
-
-        Ok(())
+        WebSimulatorDisplay {
+            size: Size::new(size.0, size.1),
+            canvas_size: Size::new(canvas_width, canvas_height),
+            backing: vec![0; (4 * canvas_width * canvas_height) as usize],
+            canvas,
+            context,
+            output_settings: output_settings.clone(),
+            _color_type: PhantomData,
+        }
     }
 }
-
 impl<C> OriginDimensions for WebSimulatorDisplay<C>
 where
     C: PixelColor + Into<Rgb888>,
@@ -152,17 +100,42 @@ where
     where
         I: IntoIterator<Item = Pixel<Self::Color>>,
     {
-        let bounding_box = primitives::Rectangle::new(Point::new(0, 0), self.size);
+        let canvas_width = self.canvas_size.width as usize;
+        let backing = self.backing.as_mut_slice();
+
+        let scale = self.output_settings.scale as usize;
+
+        // source: https://github.com/embedded-graphics/simulator/blob/master/src/output_settings.rs#L39
+        let pitch = scale + self.output_settings.pixel_spacing as usize;
+
+        let bounding_box = primitives::Rectangle::new(Point::new(0, 0), self.canvas_size);
         for pixel in pixels.into_iter() {
-            if bounding_box.contains(pixel.0) {
-                self.draw_pixel(pixel)?;
+            let point = pixel.0;
+            if bounding_box.contains(point) {
+                let rgb: Rgb888 = pixel.1.into();
+                let rgb_slice = &[rgb.r(), rgb.g(), rgb.b(), 255];
+                let py = point.y as usize;
+                let px = point.x as usize;
+
+                let x_offset = px * 4 * pitch;
+                for y in 0..scale {
+                    let y_offset = py * 4 * canvas_width * pitch + y * 4 * canvas_width;
+                    for x in 0..scale {
+                        let pixel_offset = y_offset + x_offset + x * 4;
+                        backing[pixel_offset..pixel_offset + 4].copy_from_slice(rgb_slice);
+                    }
+                }
             }
         }
-        Ok(())
-    }
 
-    fn fill_solid(&mut self, area: &Rectangle, color: Self::Color) -> Result<(), Self::Error> {
-        Self::fill_rect(&self.canvas, color, area, self.output_settings.scale, 1)?;
+        let image_data = ImageData::new_with_u8_clamped_array(
+            Clamped(backing),
+            self.canvas_size.width.try_into().unwrap(),
+        )
+        .expect("could not create ImageData");
+        self.context
+            .put_image_data(&image_data, 0., 0.)
+            .expect("coult not put ImageData");
 
         Ok(())
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -4,7 +4,7 @@ use embedded_graphics::{
     geometry::Size,
     pixelcolor::{PixelColor, Rgb888},
     prelude::*,
-    primitives::{self},
+    primitives::Rectangle,
 };
 use std::{convert::TryInto, error::Error};
 use wasm_bindgen::{Clamped, JsCast};
@@ -108,7 +108,7 @@ where
         // source: https://github.com/embedded-graphics/simulator/blob/master/src/output_settings.rs#L39
         let pitch = scale + self.output_settings.pixel_spacing as usize;
 
-        let bounding_box = primitives::Rectangle::new(Point::new(0, 0), self.canvas_size);
+        let bounding_box = Rectangle::new(Point::new(0, 0), self.size);
         for pixel in pixels.into_iter() {
             let point = pixel.0;
             if bounding_box.contains(point) {

--- a/src/display.rs
+++ b/src/display.rs
@@ -135,7 +135,7 @@ where
         .expect("could not create ImageData");
         self.context
             .put_image_data(&image_data, 0., 0.)
-            .expect("coult not put ImageData");
+            .expect("could not put ImageData");
 
         Ok(())
     }


### PR DESCRIPTION
- instead of parsing CSS for every pixel color, draw directly into a persistent RGBA array. Also make copying to the actual canvas an explicit `flush()` operation.
- fix: differentiate between effective canvas dimension (includes scale+spacing) and simulated ("original") size
- fix: animation example compiles again (type mismatch)
- cleanup (variable names, unused imports, error messages)
- prettier animated example