### PR TITLE
Update to Embedded Graphics 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "embedded-graphics-web-simulator"
 description = "A web simulator using rust-embedded library with wasm"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Rahul Thakoor <rahul.thakoor@gmail.com>"]
 edition = "2018"
 categories = ["wasm", "embedded", "no-std"]
@@ -33,7 +33,7 @@ features = [
 
 
 [dependencies.embedded-graphics]
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies.js-sys]
 version = "0.3"


### PR DESCRIPTION
The new release of Embedded Graphics 0.8 requires an update of dependencies.
Here is the suggested change.